### PR TITLE
drop invalid headers in ALB for security & compliance

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -50,6 +50,7 @@ module "alb" {
   target_group_target_type                = var.target_group_target_type
   stickiness                              = var.stickiness
   lifecycle_rule_enabled                  = var.lifecycle_rule_enabled
+  drop_invalid_header_fields              = var.drop_invalid_header_fields
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -239,3 +239,9 @@ variable "dns_acm_enabled" {
   default     = false
   description = "If `true`, use the ACM ARN created by the given `dns-delegated` component. Otherwise, use the ACM ARN created by the given `acm` component."
 }
+
+variable "drop_invalid_header_fields" {
+  type        = bool
+  default     = false
+  description = "Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false)."
+}


### PR DESCRIPTION
## what
What?
* Configured ALB to remove invalid headers before forwarding requests.
* Added logging to track dropped headers.

## why
* Security: Prevents header injection attacks.
* Compliance: Ensures requests follow HTTP standards.
* Performance: Reduces load on backend servers.
* Stability: Avoids issues caused by malformed headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to control how HTTP requests with invalid header fields are handled by the load balancer, allowing you to choose between dropping these headers or passing them through by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->