### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.0, < 6.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

