### PR TITLE
feat(alb): add `certificate_arn` output and improve logic

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
   dns_delegated_certificate_obj     = lookup(local.dns_delegated_certificate, local.dns_delegated_default_domain_name, {})
   dns_delegated_certificate_arn     = lookup(local.dns_delegated_certificate_obj, "arn", "")
 
-  certificate_arn = var.dns_acm_enabled ? module.acm.outputs.arn : local.dns_delegated_certificate_arn
+  certificate_arn = module.this.enabled && var.dns_acm_enabled ? module.acm.outputs.arn : local.dns_delegated_certificate_arn
 }
 
 module "alb" {

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -57,3 +57,8 @@ output "access_logs_bucket_id" {
   description = "The S3 bucket ID for access logs"
   value       = module.alb.access_logs_bucket_id
 }
+
+output "certificate_arn" {
+  description = "SSL certificate ARN to use with the ALB"
+  value       = local.certificate_arn
+}


### PR DESCRIPTION
## what

* Updated the `certificate_arn` local variable in `src/main.tf` to only use the ACM certificate if both `module.this.enabled` and `var.dns_acm_enabled` are true, otherwise it falls back to the delegated certificate ARN.
* Added a new output `certificate_arn` in `src/outputs.tf` to expose the selected SSL certificate ARN, making it available for use outside the module.

## why

- This a conditional check for enabling the ACM certificate and exposes the selected certificate ARN as an output. The main changes ensure that the SSL certificate ARN is only set if the module is enabled, and make this ARN accessible to other modules or users.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSL certificate ARN output for load balancing configuration reference.

* **Improvements**
  * Enhanced certificate selection logic with stricter module enable controls for better configuration safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->