### PR TITLE
feat(alb): add desync mitigation mode support

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "alb" {
   source  = "cloudposse/alb/aws"
-  version = "2.4.0"
+  version = "2.5.0"
 
   vpc_id          = module.vpc.outputs.vpc_id
   subnet_ids      = module.vpc.outputs.public_subnet_ids
@@ -51,6 +51,7 @@ module "alb" {
   stickiness                              = var.stickiness
   lifecycle_rule_enabled                  = var.lifecycle_rule_enabled
   drop_invalid_header_fields              = var.drop_invalid_header_fields
+  desync_mitigation_mode                  = var.desync_mitigation_mode
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -245,3 +245,14 @@ variable "drop_invalid_header_fields" {
   default     = false
   description = "Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false)."
 }
+
+variable "desync_mitigation_mode" {
+  type        = string
+  default     = "defensive"
+  description = "How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`."
+
+  validation {
+    condition     = contains(["monitor", "defensive", "strictest"], var.desync_mitigation_mode)
+    error_message = "Allowed values: `monitor`, `defensive`, or `strictest`."
+  }
+}

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cloudposse/test-helpers/pkg/atmos"
 	helper "github.com/cloudposse/test-helpers/pkg/atmos/component-helper"
 	awshelper "github.com/cloudposse/test-helpers/pkg/aws"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,21 +42,21 @@ func (s *ComponentSuite) TestAcm() {
 
 	assert.NotNil(s.T(), options)
 
-	alb_name := atmos.Output(s.T(), options, "alb_name")
-	alb_arn := atmos.Output(s.T(), options, "alb_arn")
-	alb_arn_suffix := atmos.Output(s.T(), options, "alb_arn_suffix")
+	albName := atmos.Output(s.T(), options, "alb_name")
+	albARN := atmos.Output(s.T(), options, "alb_arn")
+	albARNSuffix := atmos.Output(s.T(), options, "alb_arn_suffix")
 
-	assert.True(s.T(), strings.HasPrefix(alb_arn_suffix, fmt.Sprintf("app/%s", alb_name)))
+	assert.True(s.T(), strings.HasPrefix(albARNSuffix, fmt.Sprintf("app/%s", albName)))
 
-	awsAccountId := aws.GetAccountId(s.T())
+	awsAccountID := aws.GetAccountId(s.T())
 
-	expectedArn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:loadbalancer/%s", awsRegion, awsAccountId, alb_arn_suffix)
-	assert.Equal(s.T(), expectedArn, alb_arn)
+	expectedArn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:loadbalancer/%s", awsRegion, awsAccountID, albARNSuffix)
+	assert.Equal(s.T(), expectedArn, albARN)
 
 	client := awshelper.NewElbV2Client(s.T(), awsRegion)
 
 	loadBalancers, err := client.DescribeLoadBalancers(context.Background(), &elasticloadbalancingv2.DescribeLoadBalancersInput{
-		LoadBalancerArns: []string{alb_arn},
+		LoadBalancerArns: []string{albARN},
 	})
 	assert.NoError(s.T(), err)
 
@@ -64,17 +64,17 @@ func (s *ComponentSuite) TestAcm() {
 		s.T().Fatal("No load balancers found")
 	}
 	loadBalancer := loadBalancers.LoadBalancers[0]
-	alb_dns_name := atmos.Output(s.T(), options, "alb_dns_name")
-	assert.Equal(s.T(), *loadBalancer.DNSName, alb_dns_name)
+	albDNSName := atmos.Output(s.T(), options, "alb_dns_name")
+	assert.Equal(s.T(), *loadBalancer.DNSName, albDNSName)
 
-	alb_zone_id := atmos.Output(s.T(), options, "alb_zone_id")
-	assert.Equal(s.T(), *loadBalancer.CanonicalHostedZoneId, alb_zone_id)
+	albZoneID := atmos.Output(s.T(), options, "alb_zone_id")
+	assert.Equal(s.T(), *loadBalancer.CanonicalHostedZoneId, albZoneID)
 
-	security_group_id := atmos.Output(s.T(), options, "security_group_id")
-	assert.Equal(s.T(), loadBalancer.SecurityGroups[0], security_group_id)
+	securityGroupID := atmos.Output(s.T(), options, "security_group_id")
+	assert.Equal(s.T(), loadBalancer.SecurityGroups[0], securityGroupID)
 
 	targetGroups, err := client.DescribeTargetGroups(context.Background(), &elasticloadbalancingv2.DescribeTargetGroupsInput{
-		LoadBalancerArn: &alb_arn,
+		LoadBalancerArn: &albARN,
 	})
 	assert.NoError(s.T(), err)
 
@@ -82,38 +82,36 @@ func (s *ComponentSuite) TestAcm() {
 		s.T().Fatal("No target groups found")
 	}
 	targetGroup := targetGroups.TargetGroups[0]
-	default_target_group_arn := atmos.Output(s.T(), options, "default_target_group_arn")
-	assert.Equal(s.T(), *targetGroup.TargetGroupArn, default_target_group_arn)
+	defaultTargetGroupARN := atmos.Output(s.T(), options, "default_target_group_arn")
+	assert.Equal(s.T(), *targetGroup.TargetGroupArn, defaultTargetGroupARN)
 
-	listener_arns := atmos.OutputList(s.T(), options, "listener_arns")
-	assert.Equal(s.T(), 2, len(listener_arns))
+	listenerARNS := atmos.OutputList(s.T(), options, "listener_arns")
+	assert.Equal(s.T(), 2, len(listenerARNS))
 
-	listeners, err := client.DescribeListeners(context.Background(), &elasticloadbalancingv2.DescribeListenersInput{LoadBalancerArn: &alb_arn})
+	listeners, err := client.DescribeListeners(context.Background(), &elasticloadbalancingv2.DescribeListenersInput{LoadBalancerArn: &albARN})
 	assert.NoError(s.T(), err)
 
 	assert.Equal(s.T(), 2, len(listeners.Listeners))
 
-	http_redirect_listener_arn := atmos.Output(s.T(), options, "http_redirect_listener_arn")
-	https_listener_arn := atmos.Output(s.T(), options, "https_listener_arn")
+	httpRedirectListenerARN := atmos.Output(s.T(), options, "http_redirect_listener_arn")
+	httpsListenerARN := atmos.Output(s.T(), options, "https_listener_arn")
 
 	for _, listener := range listeners.Listeners {
 		if *listener.Port == 443 {
-			assert.Equal(s.T(), *listener.ListenerArn, https_listener_arn)
+			assert.Equal(s.T(), *listener.ListenerArn, httpsListenerARN)
 			assert.EqualValues(s.T(), "HTTPS", listener.Protocol)
 		} else {
-			assert.Equal(s.T(), *listener.ListenerArn, http_redirect_listener_arn)
+			assert.Equal(s.T(), *listener.ListenerArn, httpRedirectListenerARN)
 			assert.EqualValues(s.T(), "HTTP", listener.Protocol)
 		}
-		assert.Contains(s.T(), listener_arns, *listener.ListenerArn)
+		assert.Contains(s.T(), listenerARNS, *listener.ListenerArn)
 	}
 
-	access_logs_bucket_id := atmos.Output(s.T(), options, "access_logs_bucket_id")
-	assert.Equal(s.T(), "", access_logs_bucket_id)
+	accessLogsBucketID := atmos.Output(s.T(), options, "access_logs_bucket_id")
+	assert.Equal(s.T(), "", accessLogsBucketID)
 
 	s.DriftTest(component, stack, nil)
-
 }
-
 
 func (s *ComponentSuite) TestEnabledFlag() {
 	const component = "alb/disabled"
@@ -127,14 +125,15 @@ func TestRunSuite(t *testing.T) {
 	suite.AddDependency(t, "vpc", "default-test", nil)
 
 	subdomain := strings.ToLower(random.UniqueId())
-	inputs := map[string]interface{}{
-		"zone_config": []map[string]interface{}{
+	inputs := map[string]any{
+		"zone_config": []map[string]any{
 			{
 				"subdomain": subdomain,
 				"zone_name": "components.cptest.test-automation.app",
 			},
 		},
 	}
+	suite.AddDependency(t, "dns-primary", "default-test", &inputs)
 	suite.AddDependency(t, "dns-delegated", "default-test", &inputs)
 	suite.AddDependency(t, "acm", "default-test", nil)
 	helper.Run(t, suite)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -124,17 +124,22 @@ func TestRunSuite(t *testing.T) {
 
 	suite.AddDependency(t, "vpc", "default-test", nil)
 
+	primaryDomain := fmt.Sprintf("%s.cptest.test-automation.app", strings.ToLower(random.UniqueId()))
+	primaryInputs := map[string]any{
+		"domain_names": []string{primaryDomain},
+	}
+	suite.AddDependency(t, "dns-primary", "default-test", &primaryInputs)
+
 	subdomain := strings.ToLower(random.UniqueId())
-	inputs := map[string]any{
+	delegatedInputs := map[string]any{
 		"zone_config": []map[string]any{
 			{
 				"subdomain": subdomain,
-				"zone_name": "components.cptest.test-automation.app",
+				"zone_name": primaryDomain,
 			},
 		},
 	}
-	suite.AddDependency(t, "dns-primary", "default-test", nil)
-	suite.AddDependency(t, "dns-delegated", "default-test", &inputs)
+	suite.AddDependency(t, "dns-delegated", "default-test", &delegatedInputs)
 	suite.AddDependency(t, "acm", "default-test", nil)
 	helper.Run(t, suite)
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -133,7 +133,7 @@ func TestRunSuite(t *testing.T) {
 			},
 		},
 	}
-	suite.AddDependency(t, "dns-primary", "default-test", &inputs)
+	suite.AddDependency(t, "dns-primary", "default-test", nil)
 	suite.AddDependency(t, "dns-delegated", "default-test", &inputs)
 	suite.AddDependency(t, "acm", "default-test", nil)
 	helper.Run(t, suite)

--- a/test/fixtures/stacks/catalog/acm.yaml
+++ b/test/fixtures/stacks/catalog/acm.yaml
@@ -8,6 +8,7 @@ components:
         domain_name: '{{ (atmos.Component "dns-delegated" "default-test").outputs.default_domain_name }}'
         process_domain_validation_options: true
         validation_method: DNS
+        dns_delegated_environment_name: ue2
         # NOTE: The following subject alternative name is automatically added by the module.
         #       Additional entries can be added by providing this input.
         # subject_alternative_names:

--- a/test/fixtures/stacks/catalog/dns-delegated.yaml
+++ b/test/fixtures/stacks/catalog/dns-delegated.yaml
@@ -6,5 +6,5 @@ components:
       vars:
         zone_config:
           - subdomain: test
-            zone_name: example.net
+            zone_name: components.cptest.test-automation.app
         request_acm_certificate: true

--- a/test/fixtures/stacks/catalog/dns-primary.yaml
+++ b/test/fixtures/stacks/catalog/dns-primary.yaml
@@ -5,5 +5,5 @@ components:
         component: dns-primary
       vars:
         domain_names:
-          - example.net
+          - components.cptest.test-automation.app
         record_config: []


### PR DESCRIPTION
## What and Why

This introduces support for configuring the desync mitigation mode on the AWS load balancer resource. It adds a new variable to control how the load balancer handles potentially risky HTTP desync requests, improving security configuration flexibility.

New desync mitigation mode support:

* Added the `desync_mitigation_mode` argument to the `aws_lb` resource in `main.tf`, allowing the load balancer's HTTP desync handling to be configured.
* Introduced a new `desync_mitigation_mode` variable in `variables.tf` with validation for accepted values (`monitor`, `defensive`, `strictest`) and a default of `defensive`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable HTTP desynchronization mitigation for the Application Load Balancer with selectable modes: monitor, defensive (default), strictest; invalid values are rejected.

* **Chores**
  * Updated Application Load Balancer integration to module version 2.5.0.

* **Tests**
  * Updated tests, inputs, fixtures and assertions to reflect the new ALB configuration and revised DNS domain values.

* **Configuration**
  * Added an environment name parameter for DNS delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->