### PR TITLE
feat: bump terraform-aws-alb to 2.5.0 and expose new target group and security controls

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "alb" {
   source  = "cloudposse/alb/aws"
-  version = "2.4.0"
+  version = "2.5.0"
 
   vpc_id          = module.vpc.outputs.vpc_id
   subnet_ids      = module.vpc.outputs.public_subnet_ids
@@ -51,6 +51,12 @@ module "alb" {
   stickiness                              = var.stickiness
   lifecycle_rule_enabled                  = var.lifecycle_rule_enabled
   drop_invalid_header_fields              = var.drop_invalid_header_fields
+
+  desync_mitigation_mode        = var.desync_mitigation_mode
+  health_check_protocol         = var.health_check_protocol
+  load_balancing_algorithm_type = var.load_balancing_algorithm_type
+  default_target_group_enabled  = var.default_target_group_enabled
+  target_group_protocol_version = var.target_group_protocol_version
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -257,3 +257,43 @@ variable "route53_zone_name" {
   default     = null
   description = "The name of the Route53 hosted zone in which to create alias records. Required when `route53_record_names` is non-empty."
 }
+
+variable "desync_mitigation_mode" {
+  type        = string
+  default     = "defensive"
+  description = "How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`."
+
+  validation {
+    condition     = contains(["monitor", "defensive", "strictest"], var.desync_mitigation_mode)
+    error_message = "Allowed values: `monitor`, `defensive`, or `strictest`."
+  }
+}
+
+variable "health_check_protocol" {
+  type        = string
+  default     = null
+  description = "The protocol to use for the healthcheck. If not specified, same as the traffic protocol"
+}
+
+variable "load_balancing_algorithm_type" {
+  type        = string
+  default     = "round_robin"
+  description = "Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups"
+}
+
+variable "default_target_group_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether the default target group should be created or not."
+}
+
+variable "target_group_protocol_version" {
+  type        = string
+  default     = "HTTP1"
+  description = "The protocol version for the default target group. One of `HTTP1`, `HTTP2`, `GRPC`."
+
+  validation {
+    condition     = contains(["HTTP1", "HTTP2", "GRPC"], var.target_group_protocol_version)
+    error_message = "Allowed values: `HTTP1`, `HTTP2`, or `GRPC`."
+  }
+}


### PR DESCRIPTION
## what

- Expose five `cloudposse/alb/aws` module inputs the component does not currently surface, passing them through to the module:
  - `target_group_protocol_version` (`HTTP1`/`HTTP2`/`GRPC`) — enables gRPC target groups through the component
  - `health_check_protocol`
  - `load_balancing_algorithm_type`
  - `default_target_group_enabled`
  - `desync_mitigation_mode` (with value validation)
- Bump the module pin from **2.4.0** to **2.5.0** (additive minor release) — required for `desync_mitigation_mode`, which was added in module 2.5.0

## why

Four of these inputs (including the gRPC protocol version) already exist in the module at the currently pinned 2.4.0, but component users cannot reach them because the component exposes no variables for them — in particular, gRPC target groups cannot be configured through this component today. The fifth (`desync_mitigation_mode`) arrived in module 2.5.0, hence the pin bump.

We (1898 & Co.) have been carrying these as local patches on our vendored copy — originally implemented by a colleague — and would rather contribute them upstream so everyone benefits and we can drop the fork.

All new variables default to the module's own defaults (`HTTP1`, `null`, `round_robin`, `true`, `defensive`), so existing deployments are unaffected. Variable definitions mirror the module's. README intentionally untouched (left to this repo's docs automation).

Supersedes #77 (same change, clean single commit).

## references

- Module inputs: cloudposse/terraform-aws-alb (`protocol_version` added in #118; `desync_mitigation_mode` added in #206 / v2.5.0)